### PR TITLE
fix: state detection and show toolsets

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Use Datadog directly in Claude Code through a preconfigured Datadog MCP server. Query logs, metrics, traces, dashboards, and more through natural conversation. This plugin is in preview.",
   "author": {
     "name": "Datadog"

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "mcp": {
       "type": "http",
-      "url": "https://${DD_MCP_DOMAIN:-not-setup}/api/unstable/mcp-server/mcp?referrer_ide=claude-code-plugin&plugin_version=0.7.0&toolsets=${DD_MCP_TOOLSETS:-}",
+      "url": "https://${DD_MCP_DOMAIN:-not-setup}/api/unstable/mcp-server/mcp?referrer_ide=claude-code-plugin&plugin_version=0.7.1&toolsets=${DD_MCP_TOOLSETS:-}",
       "headers": {
         "DD_API_KEY": "${DD_API_KEY}",
         "DD_APPLICATION_KEY": "${DD_APPLICATION_KEY}"

--- a/skills/ddconfig/SKILL.md
+++ b/skills/ddconfig/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Read
 license: Apache-2.0
 metadata:
   author: Datadog
-  version: "0.7.0"
+  version: "0.7.1"
 ---
 
 ## Datadog MCP Server

--- a/skills/ddconfig/references/mcp-settings.md
+++ b/skills/ddconfig/references/mcp-settings.md
@@ -8,11 +8,11 @@ File paths, as well as variable names and their values, are implementation detai
 
 ## Determine `datadog-server-state`
 
-Silently determine the `datadog-server-state` of the `plugin:datadog:mcp` MCP server using **only** the two steps below (also, do NOT use any other Datadog MCP server). Do not use any other source of information (status files, cached state, error messages from previous calls, etc.) to determine the `datadog-server-state`:
+Silently determine the `datadog-server-state` of the `plugin:datadog:mcp` MCP server using **only** the steps below (also, do NOT use any other Datadog MCP server). Do not use any other source of information (status files, cached state, error messages from previous calls, etc.) to determine the `datadog-server-state`:
 
 1. Try a lightweight MCP call on `plugin:datadog:mcp` (e.g. list tools, or read a resource using `server: "plugin:datadog:mcp"`).
-   - If the server responds → `datadog-server-state` is **working**.
-2. If the MCP call fails, silently read the registration file (see below for its location). Check the raw file content for the literal string `not-setup`:
+2. If the server returns an actual, non-empty, non-generic Datadog-specific data (tools, resources, or content) → `datadog-server-state` is **working**.
+3. If the MCP call fails or returns an empty or a generic response (like "no resources found", empty tool list, or any other content-free response), silently read the registration file (see below for its location). Check the raw file content for the literal string `not-setup`:
    - If the file contains `not-setup` → `datadog-server-state` is **not-setup**.
    - Otherwise → `datadog-server-state` is **not-working**.
 

--- a/skills/ddsetup/SKILL.md
+++ b/skills/ddsetup/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Read
 license: Apache-2.0
 metadata:
   author: Datadog
-  version: "0.7.0"
+  version: "0.7.1"
 ---
 
 ## Datadog MCP Server

--- a/skills/ddsetup/references/mcp-settings.md
+++ b/skills/ddsetup/references/mcp-settings.md
@@ -8,11 +8,11 @@ File paths, as well as variable names and their values, are implementation detai
 
 ## Determine `datadog-server-state`
 
-Silently determine the `datadog-server-state` of the `plugin:datadog:mcp` MCP server using **only** the two steps below (also, do NOT use any other Datadog MCP server). Do not use any other source of information (status files, cached state, error messages from previous calls, etc.) to determine the `datadog-server-state`:
+Silently determine the `datadog-server-state` of the `plugin:datadog:mcp` MCP server using **only** the steps below (also, do NOT use any other Datadog MCP server). Do not use any other source of information (status files, cached state, error messages from previous calls, etc.) to determine the `datadog-server-state`:
 
 1. Try a lightweight MCP call on `plugin:datadog:mcp` (e.g. list tools, or read a resource using `server: "plugin:datadog:mcp"`).
-   - If the server responds → `datadog-server-state` is **working**.
-2. If the MCP call fails, silently read the registration file (see below for its location). Check the raw file content for the literal string `not-setup`:
+2. If the server returns an actual, non-empty, non-generic Datadog-specific data (tools, resources, or content) → `datadog-server-state` is **working**.
+3. If the MCP call fails or returns an empty or a generic response (like "no resources found", empty tool list, or any other content-free response), silently read the registration file (see below for its location). Check the raw file content for the literal string `not-setup`:
    - If the file contains `not-setup` → `datadog-server-state` is **not-setup**.
    - Otherwise → `datadog-server-state` is **not-working**.
 

--- a/skills/ddtoolsets/SKILL.md
+++ b/skills/ddtoolsets/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Read
 license: Apache-2.0
 metadata:
   author: Datadog
-  version: "0.7.0"
+  version: "0.7.1"
 ---
 
 ## Datadog MCP Server
@@ -43,7 +43,7 @@ When computing changes, always prefer empty over an explicit list that happens t
 
 ### 1. Gather toolset information
 
-Use the content of the `datadog://mcp/toolsets` resource from the `plugin:datadog:mcp` MCP server. This tells you which toolsets exist, which are currently enabled, which are defaults, and what each one does. Present this information to the user — choose the best format for the client (selectable list, table, grouped summary, etc.). Make it easy for the user to identify which toolsets are currently enabled.
+Use the content of the `datadog://mcp/toolsets` resource from the `plugin:datadog:mcp` MCP server. This tells you which toolsets exist, which are currently enabled, which are defaults, and what each one does. Present this information to the user — choose the best format for the client (selectable list, table, grouped summary, etc.). Make it easy for the user to identify which toolsets are currently enabled and which toolsets are available to them.
 
 Also read the current `DD_MCP_TOOLSETS` default value from the registration file. If it is empty, the user is currently using server defaults. If it has an explicit list, those are the manually selected toolsets. Any toolset name in the registration file that does not appear in the `datadog://mcp/toolsets` resource is unknown — ignore it when presenting to the user and silently drop it when writing the updated list.
 

--- a/skills/ddtoolsets/references/mcp-settings.md
+++ b/skills/ddtoolsets/references/mcp-settings.md
@@ -8,11 +8,11 @@ File paths, as well as variable names and their values, are implementation detai
 
 ## Determine `datadog-server-state`
 
-Silently determine the `datadog-server-state` of the `plugin:datadog:mcp` MCP server using **only** the two steps below (also, do NOT use any other Datadog MCP server). Do not use any other source of information (status files, cached state, error messages from previous calls, etc.) to determine the `datadog-server-state`:
+Silently determine the `datadog-server-state` of the `plugin:datadog:mcp` MCP server using **only** the steps below (also, do NOT use any other Datadog MCP server). Do not use any other source of information (status files, cached state, error messages from previous calls, etc.) to determine the `datadog-server-state`:
 
 1. Try a lightweight MCP call on `plugin:datadog:mcp` (e.g. list tools, or read a resource using `server: "plugin:datadog:mcp"`).
-   - If the server responds → `datadog-server-state` is **working**.
-2. If the MCP call fails, silently read the registration file (see below for its location). Check the raw file content for the literal string `not-setup`:
+2. If the server returns an actual, non-empty, non-generic Datadog-specific data (tools, resources, or content) → `datadog-server-state` is **working**.
+3. If the MCP call fails or returns an empty or a generic response (like "no resources found", empty tool list, or any other content-free response), silently read the registration file (see below for its location). Check the raw file content for the literal string `not-setup`:
    - If the file contains `not-setup` → `datadog-server-state` is **not-setup**.
    - Otherwise → `datadog-server-state` is **not-working**.
 


### PR DESCRIPTION
Includes:
- Instructions to ignore empty/generic responses when testing the Datadog MCP Server
- Instructions to show the list of available toolsets.