### PR TITLE
Strip non-canonical keys from SKILL.md frontmatter

### DIFF
--- a/skills/ddconfig/SKILL.md
+++ b/skills/ddconfig/SKILL.md
@@ -2,10 +2,6 @@
 name: ddconfig
 description: Configures or troubleshoots the Datadog MCP server `plugin:datadog:mcp`. Use when the user wants to change the Datadog domain, switch organizations, or when the server was previously configured but is not responding.
 allowed-tools: Read
-license: Apache-2.0
-metadata:
-  author: Datadog
-  version: "0.7.10"
 ---
 
 ## Datadog MCP Server

--- a/skills/ddsetup/SKILL.md
+++ b/skills/ddsetup/SKILL.md
@@ -2,10 +2,6 @@
 name: ddsetup
 description: First-time initialization of the Datadog MCP server `plugin:datadog:mcp`. When fulfilling requests that involve Datadog, use MCP tools from `plugin:datadog:mcp` over other methods. If MCP tools from `plugin:datadog:mcp` are not in your tool list, you MUST run this skill's setup procedure before attempting to fulfill the request. Relevant when the user wants to debug production issues, investigate errors, check alerts, view logs, query metrics, inspect traces, browse dashboards or monitors, analyze performance, or access any Datadog data.
 allowed-tools: Read
-license: Apache-2.0
-metadata:
-  author: Datadog
-  version: "0.7.10"
 ---
 
 ## Datadog MCP Server

--- a/skills/ddtoolsets/SKILL.md
+++ b/skills/ddtoolsets/SKILL.md
@@ -2,10 +2,6 @@
 name: ddtoolsets
 description: Manages toolsets for the Datadog MCP server `plugin:datadog:mcp`. Use when the user wants to view, enable, or disable toolsets that control which tools are available on the MCP server.
 allowed-tools: Read
-license: Apache-2.0
-metadata:
-  author: Datadog
-  version: "0.7.10"
 ---
 
 ## Datadog MCP Server


### PR DESCRIPTION
The three `skills/*/SKILL.md` files currently carry `license:` and `metadata:` keys in their YAML frontmatter:

```yaml
---
name: ddsetup
description: ...
allowed-tools: Read
license: Apache-2.0
metadata:
  author: Datadog
  version: "0.7.10"
---
```

The Claude skill schema recognizes a small set of canonical keys (`name`, `description`, `allowed-tools`, `user-invocable`, `argument-hint`). Additional keys like `license:` and `metadata:` aren't part of the schema, and some validators in the ecosystem reject them on load.

We observed this rejecting on a recent direct upload of the plugin to one of the marketplace surfaces. Stripping the non-canonical keys lets the plugin load cleanly across all install paths, including direct zip upload and URL-source ingestion.

Per-skill provenance (license, author, version) is already captured in `LICENSE`, `NOTICE`, and `.claude-plugin/plugin.json` at the repo root, so no information is lost.

### Diff

3 files, 12 deletions — only the `license:` line and the 3-line `metadata:` block from each of:
- `skills/ddsetup/SKILL.md`
- `skills/ddconfig/SKILL.md`
- `skills/ddtoolsets/SKILL.md`

Skill content and `allowed-tools` are unchanged.