### PR TITLE
fix: use empty defaults for OAuth-mode API key headers

### DIFF
--- a/.dd_claude-code_mcp.json
+++ b/.dd_claude-code_mcp.json
@@ -4,8 +4,8 @@
       "type": "http",
       "url": "https://${DD_MCP_DOMAIN:-not-setup}/api/unstable/mcp-server/mcp?referrer_ide=claude-code-plugin&plugin_version=0.7.13&toolsets=${DD_MCP_TOOLSETS:-}",
       "headers": {
-        "DD_API_KEY": "${DD_API_KEY}",
-        "DD_APPLICATION_KEY": "${DD_APPLICATION_KEY}"
+        "DD_API_KEY": "${DD_API_KEY:-}",
+        "DD_APPLICATION_KEY": "${DD_APPLICATION_KEY:-}"
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

The MCP server config declares the `DD_API_KEY` and `DD_APPLICATION_KEY` headers as `${DD_API_KEY}` / `${DD_APPLICATION_KEY}` with no default. The plugin authenticates via OAuth by default, so these are normally unset, and Claude Code's static MCP-config validator treats a `${VAR}` reference without a default as a required variable. On a default (OAuth) install it therefore reports the server as invalid:

```
MCP server mcp invalid: Missing environment variables: DD_API_KEY, DD_APPLICATION_KEY
```

This surfaces in `/doctor` for every OAuth user even though the server connects and works. This PR gives the two headers empty defaults (`${DD_API_KEY:-}` / `${DD_APPLICATION_KEY:-}`), matching how `${DD_MCP_TOOLSETS:-}` is already handled in the same file. Behavior is unchanged: when the variables are set (advanced API-key usage) their values are used; when unset (OAuth) they resolve to empty strings instead of being flagged as missing.

## Checklist

- [x] Tests added or updated where applicable (n/a, config-only change)
- [x] Documentation updated where applicable (n/a)
- [x] No secrets, internal URLs, or other internal references included

Closes #18
