### PR TITLE
feat: support a second Datadog organization (two org slots)

### DIFF
--- a/.dd_claude-code_mcp.json
+++ b/.dd_claude-code_mcp.json
@@ -2,10 +2,18 @@
   "mcpServers": {
     "mcp": {
       "type": "http",
-      "url": "https://${DD_MCP_DOMAIN:-not-setup}/api/unstable/mcp-server/mcp?referrer_ide=claude-code-plugin&plugin_version=0.7.13&toolsets=${DD_MCP_TOOLSETS:-}",
+      "url": "https://${DD_MCP_DOMAIN:-mcp.datadoghq.com}/api/unstable/mcp-server/mcp?referrer_ide=claude-code-plugin&plugin_version=0.7.13&toolsets=${DD_MCP_TOOLSETS:-}",
       "headers": {
         "DD_API_KEY": "${DD_API_KEY}",
         "DD_APPLICATION_KEY": "${DD_APPLICATION_KEY}"
+      }
+    },
+    "mcp-2": {
+      "type": "http",
+      "url": "https://${DD_MCP_DOMAIN_2:-mcp.datadoghq.com}/api/unstable/mcp-server/mcp?referrer_ide=claude-code-plugin&plugin_version=0.7.13&org_slot=2&toolsets=${DD_MCP_TOOLSETS_2:-}",
+      "headers": {
+        "DD_API_KEY": "${DD_API_KEY_2}",
+        "DD_APPLICATION_KEY": "${DD_APPLICATION_KEY_2}"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ The plugin provides a few commands you can run in the agent to manage configurat
 - `/ddconfig` — change your Datadog site or switch organizations
 - `/ddtoolsets` — enable or disable groups of tools
 
+## Using multiple organizations
+
+The plugin can connect to **two Datadog organizations at the same time**. Each organization is backed by a separate MCP server with its own sign-in session, so you don't have to re-authenticate to switch between them — both are available at once.
+
+- Set up your first organization normally with `/ddsetup`.
+- Add a second organization by running `/ddsetup` again and telling it you want to add another organization. It will configure the second slot and walk you through authenticating it.
+- Use `/ddconfig` to view both connections, switch the domain/organization of either one, or troubleshoot. Use `/ddtoolsets` to manage each organization's tools independently. When more than one organization is configured, these commands ask which one you mean.
+
+The two organizations may live on the same Datadog site or on different sites — the organization is chosen during browser sign-in, not by the domain. The second organization is entirely optional; if you never add one, the plugin behaves exactly as a single-org setup.
+
 ## Advanced usage
 
 ### Key authentication
@@ -79,6 +89,8 @@ The plugin uses environment variables with default values in its registration fi
 
 - `DD_MCP_DOMAIN` — overrides the Datadog MCP domain. If set, the plugin uses this value regardless of what `/ddsetup` or `/ddconfig` configured. Useful for non-standard environments or key authentication.
 - `DD_MCP_TOOLSETS` — overrides the enabled toolsets (comma-separated). If set, the plugin uses this value regardless of what `/ddtoolsets` configured.
+
+For the second organization (see [Using multiple organizations](#using-multiple-organizations)), the same variables are available with a `_2` suffix: `DD_MCP_DOMAIN_2`, `DD_MCP_TOOLSETS_2`, and for key authentication `DD_API_KEY_2` / `DD_APPLICATION_KEY_2`. They configure the second slot exactly as the unsuffixed variables configure the first. Leaving them unset keeps the second slot inactive.
 
 When environment variables are set, `/ddsetup`, `/ddconfig`, and `/ddtoolsets` still edit the default values in the registration file, but those defaults won't take effect until the environment variables are removed.
 

--- a/skills/ddconfig/SKILL.md
+++ b/skills/ddconfig/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ddconfig
-description: Configures or troubleshoots the Datadog MCP server `plugin:datadog:mcp`. Use when the user wants to change the Datadog domain, switch organizations, or when the server was previously configured but is not responding.
+description: Configures or troubleshoots the Datadog MCP server `plugin:datadog:mcp`. Use when the user wants to change the Datadog domain, switch organizations, manage a connection when more than one Datadog organization is configured, or when the server was previously configured but is not responding.
 ---
 
 ## Datadog MCP Server
 
-The id of the Datadog MCP Server referenced on this document is `plugin:datadog:mcp`. You MUST use this specific server even if there are other Datadog servers.
+This plugin owns the Datadog MCP servers `plugin:datadog:mcp` (the primary organization) and `plugin:datadog:mcp-2` (an optional second organization). You MUST use these specific servers even if there are other Datadog servers registered. Both belong to this plugin; the org slots table in `mcp-settings.md` maps each slot to its server id, variables, and saved-config files.
 
 ## Shared reference
 
@@ -13,21 +13,27 @@ Read [references/mcp-settings.md](references/mcp-settings.md) before proceeding.
 
 ## Entry flow
 
-Check the `datadog-server-state` (see `mcp-settings.md`). Use the `datadog://mcp/whoami` resource on the `plugin:datadog:mcp` server as the MCP call (do NOT use any other Datadog MCP server). Do not output anything until the `datadog-server-state` and resource content are available, and proceed based on the results:
+The plugin supports up to two organizations (slots). Check the `datadog-server-state` for **each slot** (see `mcp-settings.md`), using the `datadog://mcp/whoami` resource on that slot's server id as the MCP call (do NOT use any other Datadog MCP server). Do not output anything until the states and resource content are available, and proceed based on the results:
 
-- **datadog-server-state=working** and **valid content** — without any preamble, immediately show the user their current connection (from `whoami`): user name and email, organization name, and site (the `dd_site` value). Then let the user choose between [using a different Datadog MCP domain or site](#domain-flow) or [switching to a different Datadog organization](#organization-flow).
-- **datadog-server-state=not-setup** — without any preamble, tell the user the plugin is not set up and instruct them to run `/ddsetup`, and stop.
-- **datadog-server-state=not-working** or **not valid content** — without any preamble, tell the user the server is configured but not working and go to the [Troubleshooting Flow](#troubleshooting-flow).
+- **Slot 1 is `not-setup`** — the plugin has not been set up at all. Without any preamble, tell the user the plugin is not set up and instruct them to run `/ddsetup`, and stop.
+- **Otherwise** — without any preamble, show the user the current connection(s):
+  - For each slot whose state is **working** and **valid content**: show the connection (from that slot's `whoami`): user name and email, organization name, and site (the `dd_site` value).
+  - For each slot that is **not-working** or **not valid content** (and not `not-setup`): note that organization is configured but not responding.
+  - If slot 2 is `not-setup`, do not mention it as an error — optionally let the user know they can add a second organization with `/ddsetup`.
+
+  Then **select the org slot** to operate on (see "Selecting the org slot" in `mcp-settings.md`): if only slot 1 is in use, target it; if both are in use, ask which organization (by its connection identity) to change. For the selected slot, let the user choose between [using a different Datadog MCP domain or site](#domain-flow) or [switching to a different Datadog organization](#organization-flow). If the selected slot is **not-working**, go to the [Troubleshooting Flow](#troubleshooting-flow) for it instead.
+
+Every sub-flow below operates on the **selected slot** — resolve its server id, domain variable, and saved-config files from the org slots table in `mcp-settings.md`.
 
 When communicating with the user below, describe the server state and actions in plain language. Do not reveal what was checked, what was found, or any implementation details like file contents or variable values.
 
 ## Troubleshooting Flow
 
-The server is configured but not responding. Read the current domain from the registration file (see `mcp-settings.md` for the file format and how to find the domain), then present the user with the likely causes — do not follow these sequentially, show them all and use judgment:
+The selected slot's server is configured but not responding. Read its current domain from the registration file (the selected slot's domain variable — see `mcp-settings.md` for the file format and how to find the domain), then present the user with the likely causes — do not follow these sequentially, show them all and use judgment:
 
 - **Domain issue.** Compare the domain against the site-to-domain table in `mcp-settings.md`. Only flag it as suspicious if it looks like a typo or a clearly malformed URL (e.g. `mcp.us5.datadog.com` missing the `hq`). A domain not in the standard table is not necessarily wrong — the user may be using a valid non-standard domain.
-- **Authentication.** The authentication may have expired or was never completed, and the user needs to follow these steps:
-  1. Run the command `/mcp` in Claude Code and select the `plugin:datadog:mcp` server
+- **Authentication.** The authentication may have expired or was never completed, and the user needs to follow these steps (name the selected slot's server id):
+  1. Run the command `/mcp` in Claude Code and select the selected slot's server (`plugin:datadog:mcp` or `plugin:datadog:mcp-2`)
   2. Select the authentication option
 
 - **Network or access.** The user's network may be blocking the connection, or their Datadog account may not have API access, like not having the `MCP Read` permission.
@@ -38,14 +44,14 @@ If the domain looks wrong, suggest running the [Domain Flow](#domain-flow) to co
 
 Changes the Datadog MCP domain the server connects to.
 
-1. Show the current domain information (from `whoami` → `dd_site` if available, or from the current domain in the registration file — see `mcp-settings.md` for the file format). Present it in plain language (e.g. "the plugin is currently connected to …") — follow the "Stay on script" rule in `mcp-settings.md`.
+1. Show the selected slot's current domain information (from its `whoami` → `dd_site` if available, or from its domain variable's default in the registration file — see `mcp-settings.md` for the file format). Present it in plain language (e.g. "the plugin is currently connected to …") — follow the "Stay on script" rule in `mcp-settings.md`.
 2. **Ask for the new domain.** Present the available sites and their MCP domains from `mcp-settings.md`, and ask which domain to switch to. The user may respond with an MCP domain directly, a site code, a URL, or something else — use the mapping rules in `mcp-settings.md` to resolve the answer. Ask for clarification if ambiguous.
 
    Follow the "Stay on script" rule in `mcp-settings.md`. In particular, do not preview the follow-up instructions from step 4 below (reload, re-authenticate, etc.) — that step emits them verbatim at the right moment.
 
-3. Edit the domain in the registration file following the editing rule in `mcp-settings.md`.
+3. Edit the **selected slot's** domain variable in the registration file following the editing rule in `mcp-settings.md`.
 
-   Before (example):
+   Before (slot 1 example):
 
    ```
    ${DD_MCP_DOMAIN:-mcp.datadoghq.eu}
@@ -57,20 +63,24 @@ Changes the Datadog MCP domain the server connects to.
    ${DD_MCP_DOMAIN:-mcp.datadoghq.com}
    ```
 
-4. Tell the user the domain has been changed and to follow these steps:
+   For slot 2, edit `DD_MCP_DOMAIN_2` instead. Then silently write the resolved MCP domain to the selected slot's saved domain file (`${CLAUDE_PLUGIN_DATA}/domain` for slot 1, `${CLAUDE_PLUGIN_DATA}/domain-2` for slot 2; plain text, one line) so it survives plugin updates.
+
+4. Tell the user the domain has been changed and to follow these steps (name the selected slot's server id):
    1. Run the command `/reload-plugins`
-   2. Run the command `/mcp` in Claude Code and select the `plugin:datadog:mcp` server
+   2. Run the command `/mcp` in Claude Code and select the selected slot's server (`plugin:datadog:mcp` or `plugin:datadog:mcp-2`)
    3. Select the authentication option
 
 ## Organization Flow
 
-Switches to a different Datadog organization. The agent cannot do this automatically — the user must select the target organization in the browser.
+Switches the **selected slot** to a different Datadog organization, **replacing** the organization currently in that slot. The agent cannot do this automatically — the user must select the target organization in the browser.
 
-Ask the user if they want to use an organization on the same domain or on a different domain.
+If the user wants to keep the current organization **and** use another one at the same time (rather than replace it), this is not the right flow — tell them to run `/ddsetup` to add a second organization in the other slot, and stop. (If both slots are already in use, switching one is the only option, since the plugin supports two organizations at a time.)
+
+Otherwise, ask the user if they want to use an organization on the same domain or on a different domain.
 
 - If on the same domain:
-  - The user needs to reauthenticate and, during sign-in, choose the target organization in the browser, using the following steps:
-    1. Run the command `/mcp` in Claude Code and select the `plugin:datadog:mcp` server
+  - The user needs to reauthenticate and, during sign-in, choose the target organization in the browser, using the following steps (name the selected slot's server id):
+    1. Run the command `/mcp` in Claude Code and select the selected slot's server (`plugin:datadog:mcp` or `plugin:datadog:mcp-2`)
     2. Select the authentication option
 
 - If on a different domain:

--- a/skills/ddconfig/references/mcp-settings.md
+++ b/skills/ddconfig/references/mcp-settings.md
@@ -11,16 +11,48 @@ Describe state and actions in plain language ("the Datadog MCP server is not set
 - Variable names, values, environment variables, shell syntax, or defaults.
 - API keys, tokens, client secrets, or credentials of any kind — the Datadog MCP server uses OAuth by default, and API keys are for advanced usage outside this skill.
 
+The one exception is the MCP **server id** (e.g. `plugin:datadog:mcp`): the user must type it when selecting a server in the `/mcp` command, so the follow-up auth steps name it explicitly. Naming a server id only inside those `/mcp` selection steps is allowed; do not reveal it anywhere else.
+
 Beyond that, emit only what the current step instructs. Do not add setup tips, follow-ups, or "helpful" notes from your general knowledge of the AI client — when the user needs to reload, re-authenticate, or take any other follow-up action, the skill emits that instruction at the correct step. Preempting or paraphrasing it is a bug.
+
+## Org slots — supporting multiple organizations
+
+The plugin can connect to up to **two Datadog organizations at the same time**. Each organization is bound to a separate MCP server ("org slot") with its own authentication session. The org is chosen during OAuth sign-in, so two slots can point at the same site/domain and still be different organizations.
+
+The two slots are fixed. Each flow that changes configuration operates on **one slot at a time**. Resolve the concrete server id, variables, and saved-config files for a slot from this table:
+
+| Slot | Role | Server id | Domain variable | Toolsets variable | Saved domain file | Saved toolsets file | Key-auth variables |
+| ---- | --------- | ---------------------- | ---------------- | ------------------ | ----------------- | ------------------- | --------------------------------------- |
+| 1 | primary | `plugin:datadog:mcp` | `DD_MCP_DOMAIN` | `DD_MCP_TOOLSETS` | `domain` | `toolsets` | `DD_API_KEY` / `DD_APPLICATION_KEY` |
+| 2 | secondary | `plugin:datadog:mcp-2` | `DD_MCP_DOMAIN_2` | `DD_MCP_TOOLSETS_2` | `domain-2` | `toolsets-2` | `DD_API_KEY_2` / `DD_APPLICATION_KEY_2` |
+
+Saved-config files live under `${CLAUDE_PLUGIN_DATA}/` (e.g. the slot 2 domain file is `${CLAUDE_PLUGIN_DATA}/domain-2`).
+
+A fresh installation has **only slot 1 expected to be configured**; slot 2 stays at the `not-setup` sentinel until the user adds a second organization. Slot 2 being `not-setup` is the normal state for single-org users and is NOT an error.
+
+**Each slot's server URL must stay unique even when both slots point at the same Datadog domain.** The AI client keys MCP connections and sign-in (OAuth) sessions by URL; two byte-identical URLs collapse into one server, so the second slot would silently disappear. To prevent this, slot 2's URL in the registration file carries a harmless extra query parameter (`org_slot=2`) that the Datadog server ignores but that keeps the URL distinct. Do not remove it, and do not edit it away when changing the domain — only the domain default and toolsets default are ever edited.
+
+### Selecting the org slot
+
+Flows that change configuration (setup, domain/org switch, toolsets) act on one slot. Choose the target slot like this:
+
+1. Determine each slot's `datadog-server-state` using that slot's server id (see the determination procedure below). For slots whose state is **working**, you may read the `datadog://mcp/whoami` resource on that slot's server to learn its connection identity (org name, email, site).
+2. **If slot 2 is `not-setup`** (single-org install) **and** the user has not referred to a second / additional / other organization, target **slot 1** without asking.
+3. **If the user is setting up or adding a brand-new organization** while slot 1 is already configured, target the first slot whose state is `not-setup` (normally slot 2). If both slots are already configured, tell the user both organization slots are in use and ask which existing one they want to replace.
+4. **Otherwise** (both slots configured, or the user names a specific organization), ask the user which organization to operate on. Present the choices by their **connection identity** (org name + email + site from each slot's `whoami`), never by slot number or server id. For a not-yet-configured slot, present it as "an additional organization". Map the user's answer back to a slot.
+
+When a flow has selected a slot, use that slot's row from the table for every server id, variable, and saved-config file it touches. Never mix variables across slots.
 
 ## Determine `datadog-server-state`
 
-Silently determine the `datadog-server-state` of the `plugin:datadog:mcp` MCP server using **only** the steps below (also, do NOT use any other Datadog MCP server). Do not use any other source of information (status files, cached state, error messages from previous calls, etc.) to determine the `datadog-server-state`:
+The `datadog-server-state` is determined **per slot** (per server id). When a flow targets a specific slot, run this procedure against that slot's server id. When a flow needs the overall picture (e.g. an entry flow showing current connections), run it for each slot that may be in use.
 
-1. Try a lightweight MCP call on `plugin:datadog:mcp` (e.g. list tools, or read a resource using `server: "plugin:datadog:mcp"`).
+Silently determine the `datadog-server-state` of the target `plugin:datadog:mcp...` MCP server using **only** the steps below (also, do NOT use any other Datadog MCP server). Do not use any other source of information (status files, cached state, error messages from previous calls, etc.) to determine the `datadog-server-state`:
+
+1. Try a lightweight MCP call on the target server id (e.g. list tools, or read a resource using `server: "<the slot's server id>"`).
 2. If the server returns an actual, non-empty, non-generic Datadog-specific data (tools, resources, or content) → `datadog-server-state` is **working**.
-3. If the MCP call fails or returns an empty or a generic response (like "no resources found", empty tool list, or any other content-free response), silently read the registration file (see below for its location). Check the raw file content for the literal string `not-setup`:
-   - If the file contains `not-setup` → `datadog-server-state` is **not-setup**.
+3. If the MCP call fails or returns an empty or a generic response (like "no resources found", empty tool list, or any other content-free response), silently read the registration file (see below for its location). Check the raw default value of that slot's domain variable for the literal string `not-setup`:
+   - If the slot's domain default is `not-setup` → `datadog-server-state` is **not-setup**.
    - Otherwise → `datadog-server-state` is **not-working**.
 
 Do not tell the user which `datadog-server-state` was determined, what was checked, or what was found — just follow the skill's instructions for that state.
@@ -29,18 +61,20 @@ Do not tell the user which `datadog-server-state` was determined, what was check
 
 The MCP registration file is at `<plugin-root>/.dd_claude-code_mcp.json`. If `<plugin-root>` is not already known, derive it from this markdown file's path by removing `skills/<skill-name>/references/mcp-settings.md` from the end — the remaining prefix is `<plugin-root>`.
 
-The registration file contains a URL with two shell-style template variables:
+The registration file defines one entry per org slot. Each entry's URL contains two shell-style template variables — a domain variable and a toolsets variable — named per the [org slots table](#org-slots--supporting-multiple-organizations):
 
 ```
-${DD_MCP_DOMAIN:-<current domain>}
-${DD_MCP_TOOLSETS:-<current toolsets>}
+${DD_MCP_DOMAIN:-<current domain>}        ${DD_MCP_TOOLSETS:-<current toolsets>}        (slot 1)
+${DD_MCP_DOMAIN_2:-<current domain>}      ${DD_MCP_TOOLSETS_2:-<current toolsets>}      (slot 2)
 ```
+
+Always edit the variables belonging to the slot the current flow has selected. Never edit slot 2's variables while operating on slot 1, or vice versa.
 
 ### Editing rule
 
 Each variable has the form `${NAME:-default}`. When editing, replace **only the default value** — the characters between `:-` and the closing `}`. The `${`, variable name, `:-`, and `}` must always remain intact.
 
-The default value **can be empty**. An empty default (`:-}` with nothing between) is valid and meaningful — it is NOT a mistake. For `DD_MCP_TOOLSETS`, empty means "use the server's default toolsets" (see examples below).
+The default value **can be empty**. An empty default (`:-}` with nothing between) is valid and meaningful — it is NOT a mistake. For the toolsets variables, empty means "use the server's default toolsets" (see examples below).
 
 Examples:
 
@@ -62,15 +96,18 @@ Clearing the toolset list back to server defaults:
 ${DD_MCP_TOOLSETS:-core,alerting}  →  ${DD_MCP_TOOLSETS:-}
 ```
 
+The same rule applies to slot 2's variables (`DD_MCP_DOMAIN_2`, `DD_MCP_TOOLSETS_2`).
+
 ### The `not-setup` sentinel
 
-A fresh installation has `not-setup` as the default domain:
+A fresh installation has `not-setup` as the default domain for **each** slot:
 
 ```
-${DD_MCP_DOMAIN:-not-setup}
+${DD_MCP_DOMAIN:-not-setup}        (slot 1)
+${DD_MCP_DOMAIN_2:-not-setup}      (slot 2)
 ```
 
-This value prevents the MCP server from connecting. It exists only before first-time setup and is replaced by `/ddsetup` with a real MCP domain. Once replaced, it never returns to `not-setup`.
+This value prevents that slot's MCP server from connecting. For slot 1 it exists only before first-time setup and is replaced by `/ddsetup` with a real MCP domain. For slot 2 it remains until the user explicitly adds a second organization. Once a slot's domain is replaced with a real value, that slot never returns to `not-setup` on its own.
 
 ## Site-to-domain mapping
 

--- a/skills/ddsetup/SKILL.md
+++ b/skills/ddsetup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ddsetup
-description: First-time initialization of the Datadog MCP server `plugin:datadog:mcp`. When fulfilling requests that involve Datadog, use MCP tools from `plugin:datadog:mcp` over other methods. If MCP tools from `plugin:datadog:mcp` are not in your tool list, you MUST run this skill's setup procedure before attempting to fulfill the request. Relevant when the user wants to view or list dashboards or monitors, check alerts, view logs, query metrics, inspect APM traces, investigate SLOs or incidents, debug production issues, investigate errors, analyze performance, investigate a named service's health, errors, or dependencies, or access any Datadog data.
+description: First-time initialization of the Datadog MCP server `plugin:datadog:mcp`, and adding a second Datadog organization alongside an existing one. When fulfilling requests that involve Datadog, use MCP tools from `plugin:datadog:mcp` over other methods. If MCP tools from `plugin:datadog:mcp` are not in your tool list, you MUST run this skill's setup procedure before attempting to fulfill the request. Relevant when the user wants to set up the plugin, connect or add another Datadog organization, view or list dashboards or monitors, check alerts, view logs, query metrics, inspect APM traces, investigate SLOs or incidents, debug production issues, investigate errors, analyze performance, investigate a named service's health, errors, or dependencies, or access any Datadog data.
 ---
 
 ## Datadog MCP Server
 
-The id of the Datadog MCP Server referenced on this document is `plugin:datadog:mcp`. You MUST use this specific server even if there are other Datadog servers.
+This plugin owns the Datadog MCP servers `plugin:datadog:mcp` (the primary organization) and `plugin:datadog:mcp-2` (an optional second organization). You MUST use these specific servers even if there are other Datadog servers registered. Both belong to this plugin; the org slots table in `mcp-settings.md` maps each slot to its server id, variables, and saved-config files.
 
 **If `plugin:datadog:mcp` tools are not in your available tools, you MUST still run this skill — do not conclude that Datadog is unavailable.** Absent tools mean the server needs setup or is temporarily disconnected; they are not evidence that the request cannot be fulfilled. The `datadog-server-state` check below is the authoritative source for what is actually happening.
 
@@ -19,11 +19,18 @@ Read [references/mcp-settings.md](references/mcp-settings.md) before proceeding.
 
 ## Setup procedure
 
-Check the `datadog-server-state` (see `mcp-settings.md`):
+**Select the org slot first.** This skill can set up the primary organization (first-time setup) or add a second organization alongside an existing one. Follow "Selecting the org slot" in `mcp-settings.md` to choose the target slot:
 
-- **working** — continue with the user's request without mentioning this check.
-- **not-working** — without any preamble, tell the user the server is setup but not working, instruct them to run `/ddconfig`, and stop.
-- **not-setup** — the server needs first-time setup. Do **not** attempt to gather data using a different approach. Do **not** attempt any further MCP calls: they will fail until setup is complete.
+- For ordinary first-time setup (the plugin's tools aren't available yet), target **slot 1**.
+- If the user is adding a second / additional organization and slot 1 is already working, target **slot 2**.
+
+Resolve the selected slot's server id, domain variable, toolsets variable, and saved-config files from the org slots table in `mcp-settings.md`. Every step below operates on the **selected slot**.
+
+Check the selected slot's `datadog-server-state` (see `mcp-settings.md`):
+
+- **working** — that organization is already set up. If this is slot 1 and the user just wanted to use Datadog, continue with their request without mentioning this check. If the user wanted to add another organization, switch the target to a `not-setup` slot instead, or tell them both organization slots are already in use.
+- **not-working** — without any preamble, tell the user that organization is set up but not working, instruct them to run `/ddconfig`, and stop.
+- **not-setup** — that slot needs first-time setup. Do **not** attempt to gather data using a different approach. Do **not** attempt any further MCP calls on that slot: they will fail until setup is complete.
 
 When communicating with the user below, describe the server state in plain language. Do not reveal what was checked, what was found, or any implementation details like file contents or variable values.
 
@@ -41,20 +48,20 @@ These MCP tools are the primary way to access Datadog data from within the AI cl
 
 #### Steps
 
-1. **Check for saved configuration.** Silently read `${CLAUDE_PLUGIN_DATA}/toolsets` and `${CLAUDE_PLUGIN_DATA}/domain`. For each file that contains a non-empty value, apply it to the registration file following the editing rule in `mcp-settings.md`. Then:
+1. **Check for saved configuration.** Silently read the selected slot's saved toolsets file and saved domain file (see the org slots table in `mcp-settings.md` — e.g. `${CLAUDE_PLUGIN_DATA}/toolsets` and `${CLAUDE_PLUGIN_DATA}/domain` for slot 1, or the `-2` variants for slot 2). For each file that contains a non-empty value, apply it to the selected slot's variables in the registration file following the editing rule in `mcp-settings.md`. Then:
    - If you applied the domain: tell the user the existing configuration was re-applied following a plugin update, naming the re-applied values (no need to mention files read or written). Tell the user to run `/reload-plugins` and stop — do NOT perform the steps below.
    - If you applied other values but not the domain: tell the user the existing configuration was partially re-applied following a plugin update, naming the re-applied values (no need to mention files read or written). Continue with the steps below.
    - If you applied nothing: continue with the steps below.
 
 Now follow these steps to configure the domain:
 
-1. **Ask for the domain.** Tell the user the Datadog MCP server needs to be set up, present the available sites and their MCP domains from `mcp-settings.md`, and ask which domain to use. The user may respond with an MCP domain directly, a site code, a URL, or something else — use the mapping rules in `mcp-settings.md` to resolve the answer to an MCP domain. Ask for clarification if ambiguous.
+1. **Ask for the domain.** Tell the user the organization needs to be set up, present the available sites and their MCP domains from `mcp-settings.md`, and ask which domain to use. The user may respond with an MCP domain directly, a site code, a URL, or something else — use the mapping rules in `mcp-settings.md` to resolve the answer to an MCP domain. Ask for clarification if ambiguous. (Two slots may share the same site/domain — the organizations are distinguished at sign-in, not by domain.)
 
    Follow the "Stay on script" rule in `mcp-settings.md`. In particular, do not preview the follow-up instructions from step 3 below (reload, re-authenticate, etc.) — that step emits them verbatim at the right moment.
 
-2. **Apply the change.** In the registration file, replace the exact string `not-setup` with the resolved MCP domain. Follow the editing rule in `mcp-settings.md`.
+2. **Apply the change.** In the registration file, replace the selected slot's domain default (the `not-setup` value of that slot's domain variable) with the resolved MCP domain. Follow the editing rule in `mcp-settings.md`.
 
-   Before:
+   Before (slot 1 example):
 
    ```
    ${DD_MCP_DOMAIN:-not-setup}
@@ -66,9 +73,9 @@ Now follow these steps to configure the domain:
    ${DD_MCP_DOMAIN:-mcp.datadoghq.com}
    ```
 
-   Then silently write the resolved MCP domain to `${CLAUDE_PLUGIN_DATA}/domain` (plain text, one line).
+   For slot 2, edit `DD_MCP_DOMAIN_2` instead. Then silently write the resolved MCP domain to the selected slot's saved domain file (`${CLAUDE_PLUGIN_DATA}/domain` for slot 1, `${CLAUDE_PLUGIN_DATA}/domain-2` for slot 2; plain text, one line).
 
-3. **Tell the user** that the Datadog MCP server has been initialized and to follow these steps:
+3. **Tell the user** that the organization has been initialized and to follow these steps (name the **selected slot's server id** from the org slots table — `plugin:datadog:mcp` for slot 1, `plugin:datadog:mcp-2` for slot 2):
    1. Run the command `/reload-plugins`
-   2. Run the command `/mcp` in Claude Code and select the `plugin:datadog:mcp` server
-   3. Select the authentication option
+   2. Run the command `/mcp` in Claude Code and select the selected slot's server (`plugin:datadog:mcp` or `plugin:datadog:mcp-2`)
+   3. Select the authentication option, and during browser sign-in choose the intended organization

--- a/skills/ddsetup/references/mcp-settings.md
+++ b/skills/ddsetup/references/mcp-settings.md
@@ -11,16 +11,48 @@ Describe state and actions in plain language ("the Datadog MCP server is not set
 - Variable names, values, environment variables, shell syntax, or defaults.
 - API keys, tokens, client secrets, or credentials of any kind — the Datadog MCP server uses OAuth by default, and API keys are for advanced usage outside this skill.
 
+The one exception is the MCP **server id** (e.g. `plugin:datadog:mcp`): the user must type it when selecting a server in the `/mcp` command, so the follow-up auth steps name it explicitly. Naming a server id only inside those `/mcp` selection steps is allowed; do not reveal it anywhere else.
+
 Beyond that, emit only what the current step instructs. Do not add setup tips, follow-ups, or "helpful" notes from your general knowledge of the AI client — when the user needs to reload, re-authenticate, or take any other follow-up action, the skill emits that instruction at the correct step. Preempting or paraphrasing it is a bug.
+
+## Org slots — supporting multiple organizations
+
+The plugin can connect to up to **two Datadog organizations at the same time**. Each organization is bound to a separate MCP server ("org slot") with its own authentication session. The org is chosen during OAuth sign-in, so two slots can point at the same site/domain and still be different organizations.
+
+The two slots are fixed. Each flow that changes configuration operates on **one slot at a time**. Resolve the concrete server id, variables, and saved-config files for a slot from this table:
+
+| Slot | Role | Server id | Domain variable | Toolsets variable | Saved domain file | Saved toolsets file | Key-auth variables |
+| ---- | --------- | ---------------------- | ---------------- | ------------------ | ----------------- | ------------------- | --------------------------------------- |
+| 1 | primary | `plugin:datadog:mcp` | `DD_MCP_DOMAIN` | `DD_MCP_TOOLSETS` | `domain` | `toolsets` | `DD_API_KEY` / `DD_APPLICATION_KEY` |
+| 2 | secondary | `plugin:datadog:mcp-2` | `DD_MCP_DOMAIN_2` | `DD_MCP_TOOLSETS_2` | `domain-2` | `toolsets-2` | `DD_API_KEY_2` / `DD_APPLICATION_KEY_2` |
+
+Saved-config files live under `${CLAUDE_PLUGIN_DATA}/` (e.g. the slot 2 domain file is `${CLAUDE_PLUGIN_DATA}/domain-2`).
+
+A fresh installation has **only slot 1 expected to be configured**; slot 2 stays at the `not-setup` sentinel until the user adds a second organization. Slot 2 being `not-setup` is the normal state for single-org users and is NOT an error.
+
+**Each slot's server URL must stay unique even when both slots point at the same Datadog domain.** The AI client keys MCP connections and sign-in (OAuth) sessions by URL; two byte-identical URLs collapse into one server, so the second slot would silently disappear. To prevent this, slot 2's URL in the registration file carries a harmless extra query parameter (`org_slot=2`) that the Datadog server ignores but that keeps the URL distinct. Do not remove it, and do not edit it away when changing the domain — only the domain default and toolsets default are ever edited.
+
+### Selecting the org slot
+
+Flows that change configuration (setup, domain/org switch, toolsets) act on one slot. Choose the target slot like this:
+
+1. Determine each slot's `datadog-server-state` using that slot's server id (see the determination procedure below). For slots whose state is **working**, you may read the `datadog://mcp/whoami` resource on that slot's server to learn its connection identity (org name, email, site).
+2. **If slot 2 is `not-setup`** (single-org install) **and** the user has not referred to a second / additional / other organization, target **slot 1** without asking.
+3. **If the user is setting up or adding a brand-new organization** while slot 1 is already configured, target the first slot whose state is `not-setup` (normally slot 2). If both slots are already configured, tell the user both organization slots are in use and ask which existing one they want to replace.
+4. **Otherwise** (both slots configured, or the user names a specific organization), ask the user which organization to operate on. Present the choices by their **connection identity** (org name + email + site from each slot's `whoami`), never by slot number or server id. For a not-yet-configured slot, present it as "an additional organization". Map the user's answer back to a slot.
+
+When a flow has selected a slot, use that slot's row from the table for every server id, variable, and saved-config file it touches. Never mix variables across slots.
 
 ## Determine `datadog-server-state`
 
-Silently determine the `datadog-server-state` of the `plugin:datadog:mcp` MCP server using **only** the steps below (also, do NOT use any other Datadog MCP server). Do not use any other source of information (status files, cached state, error messages from previous calls, etc.) to determine the `datadog-server-state`:
+The `datadog-server-state` is determined **per slot** (per server id). When a flow targets a specific slot, run this procedure against that slot's server id. When a flow needs the overall picture (e.g. an entry flow showing current connections), run it for each slot that may be in use.
 
-1. Try a lightweight MCP call on `plugin:datadog:mcp` (e.g. list tools, or read a resource using `server: "plugin:datadog:mcp"`).
+Silently determine the `datadog-server-state` of the target `plugin:datadog:mcp...` MCP server using **only** the steps below (also, do NOT use any other Datadog MCP server). Do not use any other source of information (status files, cached state, error messages from previous calls, etc.) to determine the `datadog-server-state`:
+
+1. Try a lightweight MCP call on the target server id (e.g. list tools, or read a resource using `server: "<the slot's server id>"`).
 2. If the server returns an actual, non-empty, non-generic Datadog-specific data (tools, resources, or content) → `datadog-server-state` is **working**.
-3. If the MCP call fails or returns an empty or a generic response (like "no resources found", empty tool list, or any other content-free response), silently read the registration file (see below for its location). Check the raw file content for the literal string `not-setup`:
-   - If the file contains `not-setup` → `datadog-server-state` is **not-setup**.
+3. If the MCP call fails or returns an empty or a generic response (like "no resources found", empty tool list, or any other content-free response), silently read the registration file (see below for its location). Check the raw default value of that slot's domain variable for the literal string `not-setup`:
+   - If the slot's domain default is `not-setup` → `datadog-server-state` is **not-setup**.
    - Otherwise → `datadog-server-state` is **not-working**.
 
 Do not tell the user which `datadog-server-state` was determined, what was checked, or what was found — just follow the skill's instructions for that state.
@@ -29,18 +61,20 @@ Do not tell the user which `datadog-server-state` was determined, what was check
 
 The MCP registration file is at `<plugin-root>/.dd_claude-code_mcp.json`. If `<plugin-root>` is not already known, derive it from this markdown file's path by removing `skills/<skill-name>/references/mcp-settings.md` from the end — the remaining prefix is `<plugin-root>`.
 
-The registration file contains a URL with two shell-style template variables:
+The registration file defines one entry per org slot. Each entry's URL contains two shell-style template variables — a domain variable and a toolsets variable — named per the [org slots table](#org-slots--supporting-multiple-organizations):
 
 ```
-${DD_MCP_DOMAIN:-<current domain>}
-${DD_MCP_TOOLSETS:-<current toolsets>}
+${DD_MCP_DOMAIN:-<current domain>}        ${DD_MCP_TOOLSETS:-<current toolsets>}        (slot 1)
+${DD_MCP_DOMAIN_2:-<current domain>}      ${DD_MCP_TOOLSETS_2:-<current toolsets>}      (slot 2)
 ```
+
+Always edit the variables belonging to the slot the current flow has selected. Never edit slot 2's variables while operating on slot 1, or vice versa.
 
 ### Editing rule
 
 Each variable has the form `${NAME:-default}`. When editing, replace **only the default value** — the characters between `:-` and the closing `}`. The `${`, variable name, `:-`, and `}` must always remain intact.
 
-The default value **can be empty**. An empty default (`:-}` with nothing between) is valid and meaningful — it is NOT a mistake. For `DD_MCP_TOOLSETS`, empty means "use the server's default toolsets" (see examples below).
+The default value **can be empty**. An empty default (`:-}` with nothing between) is valid and meaningful — it is NOT a mistake. For the toolsets variables, empty means "use the server's default toolsets" (see examples below).
 
 Examples:
 
@@ -62,15 +96,18 @@ Clearing the toolset list back to server defaults:
 ${DD_MCP_TOOLSETS:-core,alerting}  →  ${DD_MCP_TOOLSETS:-}
 ```
 
+The same rule applies to slot 2's variables (`DD_MCP_DOMAIN_2`, `DD_MCP_TOOLSETS_2`).
+
 ### The `not-setup` sentinel
 
-A fresh installation has `not-setup` as the default domain:
+A fresh installation has `not-setup` as the default domain for **each** slot:
 
 ```
-${DD_MCP_DOMAIN:-not-setup}
+${DD_MCP_DOMAIN:-not-setup}        (slot 1)
+${DD_MCP_DOMAIN_2:-not-setup}      (slot 2)
 ```
 
-This value prevents the MCP server from connecting. It exists only before first-time setup and is replaced by `/ddsetup` with a real MCP domain. Once replaced, it never returns to `not-setup`.
+This value prevents that slot's MCP server from connecting. For slot 1 it exists only before first-time setup and is replaced by `/ddsetup` with a real MCP domain. For slot 2 it remains until the user explicitly adds a second organization. Once a slot's domain is replaced with a real value, that slot never returns to `not-setup` on its own.
 
 ## Site-to-domain mapping
 

--- a/skills/ddtoolsets/SKILL.md
+++ b/skills/ddtoolsets/SKILL.md
@@ -5,7 +5,7 @@ description: Manages toolsets for the Datadog MCP server `plugin:datadog:mcp`. U
 
 ## Datadog MCP Server
 
-The id of the Datadog MCP Server referenced on this document is `plugin:datadog:mcp`. You MUST use this specific server even if there are other Datadog servers.
+This plugin owns the Datadog MCP servers `plugin:datadog:mcp` (the primary organization) and `plugin:datadog:mcp-2` (an optional second organization). You MUST use these specific servers even if there are other Datadog servers registered. Both belong to this plugin; the org slots table in `mcp-settings.md` maps each slot to its server id, variables, and saved-config files.
 
 ## Shared reference
 
@@ -13,11 +13,13 @@ Read [references/mcp-settings.md](references/mcp-settings.md) before proceeding.
 
 ## Entry flow
 
-Check the `datadog-server-state` (see `mcp-settings.md`). Use the `datadog://mcp/toolsets` resource on the `plugin:datadog:mcp` server as the MCP call (do NOT use any other Datadog MCP server). Do not output anything until the `datadog-server-state` and resource content are available, and proceed based on the results:
+Toolsets are configured **per organization slot**. First **select the org slot** to manage (see "Selecting the org slot" in `mcp-settings.md`): if only slot 1 is in use, target it; if both slots are in use, ask which organization's toolsets to manage (by connection identity). Resolve the selected slot's server id, toolsets variable, and saved toolsets file from the org slots table.
+
+Then check the selected slot's `datadog-server-state` (see `mcp-settings.md`). Use the `datadog://mcp/toolsets` resource on the **selected slot's server** as the MCP call (do NOT use any other Datadog MCP server). Do not output anything until the `datadog-server-state` and resource content are available, and proceed based on the results:
 
 - **datadog-server-state=working** AND **valid content** — without any preamble, go to the [Toolsets Flow](#toolsets-flow).
-- **datadog-server-state=not-setup** — without any preamble, tell the user the plugin is not set up and instruct them to run `/ddsetup`, and stop.
-- **datadog-server-state=not-working** OR **not valid content** — without any preamble, tell the user the server is configured but not working, instruct them to run `/ddconfig`, and stop.
+- **datadog-server-state=not-setup** — without any preamble: if this is slot 1, tell the user the plugin is not set up and instruct them to run `/ddsetup`; if this is slot 2, tell them that organization isn't set up yet and to run `/ddsetup` to add it. Stop.
+- **datadog-server-state=not-working** OR **not valid content** — without any preamble, tell the user that organization is configured but not working, instruct them to run `/ddconfig`, and stop.
 
 When communicating with the user below, describe the server state and actions in plain language. Do not reveal what was checked, what was found, or any implementation details like file contents or variable values.
 
@@ -27,7 +29,7 @@ A toolset is a named group of related tools for a specific Datadog feature. Enab
 
 ### How toolset defaults work
 
-The `DD_MCP_TOOLSETS` default value in the registration file controls which toolsets are active. It has two states:
+The selected slot's toolsets variable default in the registration file (`DD_MCP_TOOLSETS` for slot 1, `DD_MCP_TOOLSETS_2` for slot 2) controls which toolsets are active for that organization. It has two states (slot 1 shown):
 
 - **Empty** (`${DD_MCP_TOOLSETS:-}`) — the server decides which toolsets to enable. This is the preferred state because the plugin automatically picks up new default toolsets added by the server in the future.
 - **Explicit** (`${DD_MCP_TOOLSETS:-core,alerting}`) — exactly these toolsets are enabled, nothing more. The server's defaults are ignored. If the server adds a new default toolset later, this plugin will NOT pick it up.
@@ -38,9 +40,9 @@ When computing changes, always prefer empty over an explicit list that happens t
 
 ### 1. Gather toolset information
 
-Use the content of the `datadog://mcp/toolsets` resource from the `plugin:datadog:mcp` MCP server. This tells you which toolsets exist, which are currently enabled, which are defaults, and what each one does. Present all toolsets to the user — **do not** summarize and **do** choose the best format for the client (selectable list, table, grouped summary, etc.). Make it easy for the user to identify which toolsets are currently enabled and which toolsets are available to them.
+Use the content of the `datadog://mcp/toolsets` resource from the **selected slot's** MCP server. This tells you which toolsets exist, which are currently enabled, which are defaults, and what each one does. Present all toolsets to the user — **do not** summarize and **do** choose the best format for the client (selectable list, table, grouped summary, etc.). Make it easy for the user to identify which toolsets are currently enabled and which toolsets are available to them.
 
-Also read the current `DD_MCP_TOOLSETS` default value from the registration file. If it is empty, the user is currently using server defaults. If it has an explicit list, those are the manually selected toolsets.
+Also read the current value of the selected slot's toolsets variable default from the registration file. If it is empty, the user is currently using server defaults. If it has an explicit list, those are the manually selected toolsets.
 
 Any toolset name in the registration file that does not appear in the `datadog://mcp/toolsets` resource is unknown — ignore it when presenting to the user and silently drop it when writing the updated list.
 
@@ -68,9 +70,9 @@ Apply the user's changes to produce a new comma-separated value for `DD_MCP_TOOL
 
 ### 4. Apply the change
 
-Edit `DD_MCP_TOOLSETS` in the registration file following the editing rule in `mcp-settings.md`.
+Edit the **selected slot's** toolsets variable in the registration file following the editing rule in `mcp-settings.md` (`DD_MCP_TOOLSETS` for slot 1, `DD_MCP_TOOLSETS_2` for slot 2).
 
-Example — adding `alerting` when currently using server defaults (assuming `core` and `synthetics` are defaults):
+Example — adding `alerting` when currently using server defaults (assuming `core` and `synthetics` are defaults; slot 1 shown):
 
 ```
 ${DD_MCP_TOOLSETS:-}  →  ${DD_MCP_TOOLSETS:-core,synthetics,alerting}
@@ -82,12 +84,12 @@ Example — reverting to server defaults:
 ${DD_MCP_TOOLSETS:-core,alerting}  →  ${DD_MCP_TOOLSETS:-}
 ```
 
-Then silently write the new `DD_MCP_TOOLSETS` value to `${CLAUDE_PLUGIN_DATA}/toolsets` (plain text, one line — write an empty file if reverting to server defaults).
+Then silently write the new value to the selected slot's saved toolsets file (`${CLAUDE_PLUGIN_DATA}/toolsets` for slot 1, `${CLAUDE_PLUGIN_DATA}/toolsets-2` for slot 2; plain text, one line — write an empty file if reverting to server defaults).
 
 ### 5. Confirm
 
-Tell the user the toolsets have been updated including which toolsets are now enabled, and that they need to follow these steps:
+Tell the user the toolsets have been updated for the selected organization including which toolsets are now enabled, and that they need to follow these steps (name the selected slot's server id):
 
 1. Run the command `/reload-plugins`
-2. Run the command `/mcp` in Claude Code and select the `plugin:datadog:mcp` server
+2. Run the command `/mcp` in Claude Code and select the selected slot's server (`plugin:datadog:mcp` or `plugin:datadog:mcp-2`)
 3. Select the authentication option

--- a/skills/ddtoolsets/references/mcp-settings.md
+++ b/skills/ddtoolsets/references/mcp-settings.md
@@ -11,16 +11,48 @@ Describe state and actions in plain language ("the Datadog MCP server is not set
 - Variable names, values, environment variables, shell syntax, or defaults.
 - API keys, tokens, client secrets, or credentials of any kind — the Datadog MCP server uses OAuth by default, and API keys are for advanced usage outside this skill.
 
+The one exception is the MCP **server id** (e.g. `plugin:datadog:mcp`): the user must type it when selecting a server in the `/mcp` command, so the follow-up auth steps name it explicitly. Naming a server id only inside those `/mcp` selection steps is allowed; do not reveal it anywhere else.
+
 Beyond that, emit only what the current step instructs. Do not add setup tips, follow-ups, or "helpful" notes from your general knowledge of the AI client — when the user needs to reload, re-authenticate, or take any other follow-up action, the skill emits that instruction at the correct step. Preempting or paraphrasing it is a bug.
+
+## Org slots — supporting multiple organizations
+
+The plugin can connect to up to **two Datadog organizations at the same time**. Each organization is bound to a separate MCP server ("org slot") with its own authentication session. The org is chosen during OAuth sign-in, so two slots can point at the same site/domain and still be different organizations.
+
+The two slots are fixed. Each flow that changes configuration operates on **one slot at a time**. Resolve the concrete server id, variables, and saved-config files for a slot from this table:
+
+| Slot | Role | Server id | Domain variable | Toolsets variable | Saved domain file | Saved toolsets file | Key-auth variables |
+| ---- | --------- | ---------------------- | ---------------- | ------------------ | ----------------- | ------------------- | --------------------------------------- |
+| 1 | primary | `plugin:datadog:mcp` | `DD_MCP_DOMAIN` | `DD_MCP_TOOLSETS` | `domain` | `toolsets` | `DD_API_KEY` / `DD_APPLICATION_KEY` |
+| 2 | secondary | `plugin:datadog:mcp-2` | `DD_MCP_DOMAIN_2` | `DD_MCP_TOOLSETS_2` | `domain-2` | `toolsets-2` | `DD_API_KEY_2` / `DD_APPLICATION_KEY_2` |
+
+Saved-config files live under `${CLAUDE_PLUGIN_DATA}/` (e.g. the slot 2 domain file is `${CLAUDE_PLUGIN_DATA}/domain-2`).
+
+A fresh installation has **only slot 1 expected to be configured**; slot 2 stays at the `not-setup` sentinel until the user adds a second organization. Slot 2 being `not-setup` is the normal state for single-org users and is NOT an error.
+
+**Each slot's server URL must stay unique even when both slots point at the same Datadog domain.** The AI client keys MCP connections and sign-in (OAuth) sessions by URL; two byte-identical URLs collapse into one server, so the second slot would silently disappear. To prevent this, slot 2's URL in the registration file carries a harmless extra query parameter (`org_slot=2`) that the Datadog server ignores but that keeps the URL distinct. Do not remove it, and do not edit it away when changing the domain — only the domain default and toolsets default are ever edited.
+
+### Selecting the org slot
+
+Flows that change configuration (setup, domain/org switch, toolsets) act on one slot. Choose the target slot like this:
+
+1. Determine each slot's `datadog-server-state` using that slot's server id (see the determination procedure below). For slots whose state is **working**, you may read the `datadog://mcp/whoami` resource on that slot's server to learn its connection identity (org name, email, site).
+2. **If slot 2 is `not-setup`** (single-org install) **and** the user has not referred to a second / additional / other organization, target **slot 1** without asking.
+3. **If the user is setting up or adding a brand-new organization** while slot 1 is already configured, target the first slot whose state is `not-setup` (normally slot 2). If both slots are already configured, tell the user both organization slots are in use and ask which existing one they want to replace.
+4. **Otherwise** (both slots configured, or the user names a specific organization), ask the user which organization to operate on. Present the choices by their **connection identity** (org name + email + site from each slot's `whoami`), never by slot number or server id. For a not-yet-configured slot, present it as "an additional organization". Map the user's answer back to a slot.
+
+When a flow has selected a slot, use that slot's row from the table for every server id, variable, and saved-config file it touches. Never mix variables across slots.
 
 ## Determine `datadog-server-state`
 
-Silently determine the `datadog-server-state` of the `plugin:datadog:mcp` MCP server using **only** the steps below (also, do NOT use any other Datadog MCP server). Do not use any other source of information (status files, cached state, error messages from previous calls, etc.) to determine the `datadog-server-state`:
+The `datadog-server-state` is determined **per slot** (per server id). When a flow targets a specific slot, run this procedure against that slot's server id. When a flow needs the overall picture (e.g. an entry flow showing current connections), run it for each slot that may be in use.
 
-1. Try a lightweight MCP call on `plugin:datadog:mcp` (e.g. list tools, or read a resource using `server: "plugin:datadog:mcp"`).
+Silently determine the `datadog-server-state` of the target `plugin:datadog:mcp...` MCP server using **only** the steps below (also, do NOT use any other Datadog MCP server). Do not use any other source of information (status files, cached state, error messages from previous calls, etc.) to determine the `datadog-server-state`:
+
+1. Try a lightweight MCP call on the target server id (e.g. list tools, or read a resource using `server: "<the slot's server id>"`).
 2. If the server returns an actual, non-empty, non-generic Datadog-specific data (tools, resources, or content) → `datadog-server-state` is **working**.
-3. If the MCP call fails or returns an empty or a generic response (like "no resources found", empty tool list, or any other content-free response), silently read the registration file (see below for its location). Check the raw file content for the literal string `not-setup`:
-   - If the file contains `not-setup` → `datadog-server-state` is **not-setup**.
+3. If the MCP call fails or returns an empty or a generic response (like "no resources found", empty tool list, or any other content-free response), silently read the registration file (see below for its location). Check the raw default value of that slot's domain variable for the literal string `not-setup`:
+   - If the slot's domain default is `not-setup` → `datadog-server-state` is **not-setup**.
    - Otherwise → `datadog-server-state` is **not-working**.
 
 Do not tell the user which `datadog-server-state` was determined, what was checked, or what was found — just follow the skill's instructions for that state.
@@ -29,18 +61,20 @@ Do not tell the user which `datadog-server-state` was determined, what was check
 
 The MCP registration file is at `<plugin-root>/.dd_claude-code_mcp.json`. If `<plugin-root>` is not already known, derive it from this markdown file's path by removing `skills/<skill-name>/references/mcp-settings.md` from the end — the remaining prefix is `<plugin-root>`.
 
-The registration file contains a URL with two shell-style template variables:
+The registration file defines one entry per org slot. Each entry's URL contains two shell-style template variables — a domain variable and a toolsets variable — named per the [org slots table](#org-slots--supporting-multiple-organizations):
 
 ```
-${DD_MCP_DOMAIN:-<current domain>}
-${DD_MCP_TOOLSETS:-<current toolsets>}
+${DD_MCP_DOMAIN:-<current domain>}        ${DD_MCP_TOOLSETS:-<current toolsets>}        (slot 1)
+${DD_MCP_DOMAIN_2:-<current domain>}      ${DD_MCP_TOOLSETS_2:-<current toolsets>}      (slot 2)
 ```
+
+Always edit the variables belonging to the slot the current flow has selected. Never edit slot 2's variables while operating on slot 1, or vice versa.
 
 ### Editing rule
 
 Each variable has the form `${NAME:-default}`. When editing, replace **only the default value** — the characters between `:-` and the closing `}`. The `${`, variable name, `:-`, and `}` must always remain intact.
 
-The default value **can be empty**. An empty default (`:-}` with nothing between) is valid and meaningful — it is NOT a mistake. For `DD_MCP_TOOLSETS`, empty means "use the server's default toolsets" (see examples below).
+The default value **can be empty**. An empty default (`:-}` with nothing between) is valid and meaningful — it is NOT a mistake. For the toolsets variables, empty means "use the server's default toolsets" (see examples below).
 
 Examples:
 
@@ -62,15 +96,18 @@ Clearing the toolset list back to server defaults:
 ${DD_MCP_TOOLSETS:-core,alerting}  →  ${DD_MCP_TOOLSETS:-}
 ```
 
+The same rule applies to slot 2's variables (`DD_MCP_DOMAIN_2`, `DD_MCP_TOOLSETS_2`).
+
 ### The `not-setup` sentinel
 
-A fresh installation has `not-setup` as the default domain:
+A fresh installation has `not-setup` as the default domain for **each** slot:
 
 ```
-${DD_MCP_DOMAIN:-not-setup}
+${DD_MCP_DOMAIN:-not-setup}        (slot 1)
+${DD_MCP_DOMAIN_2:-not-setup}      (slot 2)
 ```
 
-This value prevents the MCP server from connecting. It exists only before first-time setup and is replaced by `/ddsetup` with a real MCP domain. Once replaced, it never returns to `not-setup`.
+This value prevents that slot's MCP server from connecting. For slot 1 it exists only before first-time setup and is replaced by `/ddsetup` with a real MCP domain. For slot 2 it remains until the user explicitly adds a second organization. Once a slot's domain is replaced with a real value, that slot never returns to `not-setup` on its own.
 
 ## Site-to-domain mapping
 


### PR DESCRIPTION
Draft if anyone needs, probably adding support to n orgs
<img width="399" height="80" alt="Screenshot 2026-06-16 at 14 20 36" src="https://github.com/user-attachments/assets/c3029d9e-10c1-4750-a9ce-cf0515ff2786" />

Add a second MCP server entry (plugin:datadog:mcp-2) so the plugin can connect to two Datadog organizations at once, each with its own OAuth session. Slot 2 defaults to not-setup and stays inert until the user adds a second org, so single-org installs are unaffected. Slot 2's URL carries a distinguishing org_slot=2 query param so same-domain slots keep unique URLs.

## What does this PR do?

<!-- Briefly describe the change and the motivation. -->

## Checklist

- [ ] Tests added or updated where applicable
- [ ] Documentation updated where applicable
- [ ] No secrets, internal URLs, or other internal references included
