### PR TITLE
fix(release): create tag before release so it targets the triggering commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,20 +61,26 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Create tag if missing
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          # If tag doesn't exist on remote, create it at the triggering commit.
+          if ! git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG}" "${{ github.sha }}"
+            git push origin "refs/tags/${TAG}"
+          fi
+
       - name: Create release
         if: steps.check.outputs.exists == 'false'
         run: |
-          # --target pins the new tag to the commit that triggered this
-          # workflow. Without it, `gh release create` would create the
-          # missing tag on the repo's default branch (main), which would
-          # make a preview-branch release point at main instead of the
-          # preview commit — and break the downstream npm-publish step
-          # for OpenCode previews, since it derives the dist-tag from the
-          # tagged commit's package.json.
-          ARGS="--title ${{ steps.version.outputs.tag }} --generate-notes --target ${{ github.sha }}"
+          TAG="${{ steps.version.outputs.tag }}"
+          ARGS="--title ${TAG} --generate-notes"
           if [ "${{ steps.version.outputs.is_prerelease }}" = "true" ]; then
             ARGS="$ARGS --prerelease"
           fi
-          gh release create "${{ steps.version.outputs.tag }}" $ARGS
+          gh release create "${TAG}" $ARGS
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `gh release create` without a pre-existing tag creates the tag on the repo's default branch, which broke preview-branch releases by pointing the tag at `main` instead of the triggering commit.
- Explicitly create and push the tag at `${{ github.sha }}` before creating the release, so the tag (and release) point at the correct commit.

## Test plan
- [ ] Trigger the release workflow from a preview branch and confirm the created tag points at the preview commit, not main
- [ ] Confirm a normal release from main still works as expected