### PR TITLE
fix(chainguard): update repo owner to ddoghq in STS policy

### DIFF
--- a/.github/chainguard/datadog-client-plugin.publish.sts.yaml
+++ b/.github/chainguard/datadog-client-plugin.publish.sts.yaml
@@ -7,11 +7,11 @@ issuer: https://token.actions.githubusercontent.com
 # both patterns here and propagate the policy to each public repo via the
 # next stable v*-public release — tags using the new grammar will fail at
 # token-mint until the updated policy reaches the public repo's main.
-subject_pattern: 'repo:DataDog/datadog-client-plugin:ref:refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-preview\.[a-z0-9-]+)?(\+[a-z0-9-]+)?-public'
+subject_pattern: 'repo:ddoghq/datadog-client-plugin:ref:refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-preview\.[a-z0-9-]+)?(\+[a-z0-9-]+)?-public'
 
 claim_pattern:
   event_name: push
-  job_workflow_ref: 'DataDog/datadog-client-plugin/.github/workflows/publish-public.yaml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-preview\.[a-z0-9-]+)?(\+[a-z0-9-]+)?-public'
+  job_workflow_ref: 'ddoghq/datadog-client-plugin/.github/workflows/publish-public.yaml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-preview\.[a-z0-9-]+)?(\+[a-z0-9-]+)?-public'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Updates `subject_pattern` and `job_workflow_ref` in the datadog-client-plugin STS policy from `DataDog/datadog-client-plugin` to `ddoghq/datadog-client-plugin`, reflecting the repo's migration to the `ddoghq` GitHub org.

## Test plan
- [ ] Confirm this is the authoritative/deployed copy of the STS policy (not a stale duplicate)
- [ ] Verify no other policy files still reference `DataDog/datadog-client-plugin`